### PR TITLE
Add global.json and global project settings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
+    <ProjectRelativePath>$([MSBuild]::MakeRelative('$(MSBuildThisFileDirectory)', '$(MSBuildProjectDirectory)\$(MSBuildProjectName)\'))</ProjectRelativePath>
+
+    <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)artifacts\obj\$(ProjectRelativePath)</BaseIntermediateOutputPath>
+    <BaseOutputPath>$(MSBuildThisFileDirectory)artifacts\bin\$(ProjectRelativePath)</BaseOutputPath>
+
     <DebugType>Full</DebugType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <NoWarn>$(NoWarn);NU5125</NoWarn>
@@ -9,6 +14,9 @@
     <CentralPackagesFile>$(MSBuildThisFileDirectory)/Packages.props</CentralPackagesFile>
     <IsTestProject Condition=" $(MSBuildProjectName.EndsWith('.Tests')) ">true</IsTestProject>
     <RootNamespace>PCSharpGen.$(MSBuildProjectName)</RootNamespace>
+    <Deterministic>true</Deterministic>
+    <PathMap>$(MSBuildThisFileDirectory)=S:\</PathMap>
+    <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,3 +1,3 @@
 <Project>
-  <Sdk Name="Microsoft.Build.CentralPackageVersions" Version="2.0.36" />
+  <Sdk Name="Microsoft.Build.CentralPackageVersions" />
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,10 @@ variables:
 steps:
 - task: NuGetToolInstaller@1
 
+- task: UseDotNet@2
+  inputs:
+    useGlobalJson: true
+
 - task: NuGetCommand@2
   inputs:
     restoreSolution: '$(solution)'

--- a/global.json
+++ b/global.json
@@ -1,0 +1,9 @@
+{
+  "sdk": {
+    "version": "3.1.302",
+    "rollForward": "minor"
+  },
+  "msbuild-sdks": {
+    "Microsoft.Build.CentralPackageVersions": "2.0.46"
+  }
+}


### PR DESCRIPTION
This change adds a global.json with the 3.1 sdk in it, and global project settings for a consolidated output path and determinism set.